### PR TITLE
feat : Enemy클래스에 플레이어 정보 받아오고 관련된 정보 계산하고 확인하는 로직 추가 #537

### DIFF
--- a/TeamProject/Client/Private/Enemy.cpp
+++ b/TeamProject/Client/Private/Enemy.cpp
@@ -30,6 +30,7 @@ void CEnemy::Update(_float dt)
 {
 	m_PlayerCharacterInfos.clear();
 	m_PlayerCharacterInfos = CBattleSystem::GetInstance()->GetBattleObjects(CBattleSystem::BATTLE_OBJ_TYPE::PLAYER);
+	ComputeTargetingInfo();
 }
 
 BATTLEOBJ_INFO* CEnemy::GetCharacterOnField()
@@ -40,6 +41,80 @@ BATTLEOBJ_INFO* CEnemy::GetCharacterOnField()
 			return &info;
 	}
 	return nullptr;
+}
+
+void CEnemy::ComputeTargetingInfo()
+{
+	auto pTargetInfo = GetCharacterOnField();
+	if (nullptr == pTargetInfo)
+		return;
+
+	m_tTargetingInfo = {};
+	
+	m_tTargetingInfo.vTargetPos = pTargetInfo->vPos;
+	m_tTargetingInfo.vSelfPos = m_pTransform->Get_Pos();
+	m_tTargetingInfo.vDirSelfLook = m_pTransform->Dir(Engine::STATE::LOOK);
+	m_tTargetingInfo.vDirSelfLook.Normalize();
+	
+	// Y축 제거 한 수평 방향 벡터 계산 버전(XZ평면)
+	_vector3 vTargetPosH = { m_tTargetingInfo.vTargetPos.x, 0.f, m_tTargetingInfo.vTargetPos.z };
+	_vector3 vSelfPosH = { m_tTargetingInfo.vSelfPos.x, 0.f, m_tTargetingInfo.vSelfPos.z };
+	_vector3 vDirToTarget = vTargetPosH - vSelfPosH;
+
+	// Y축 제거 안한 3D 방향 벡터 계산 버전(XYZ)
+	//_vector3 vDirToTarget = m_tTargetingInfo.vTargetPos - m_tTargetingInfo.vSelfPos;
+
+	m_tTargetingInfo.fDistanceSq = vDirToTarget.LengthSquared();
+	if (m_tTargetingInfo.fDistanceSq <= m_fDetectedRange * m_fDetectedRange)
+		m_tTargetingInfo.isDetected = true;
+
+	// sqrt 계산이 비교적 무거워서 후에 최적화 필요시 아래 식 사용 고려
+	//m_tTargetingInfo.fDistance = (m_tTargetingInfo.fDistanceSq > m_fDetectedRange * m_fDetectedRange) ? 
+	//	sqrt(m_tTargetingInfo.fDistanceSq) : m_fDetectedRange;
+	m_tTargetingInfo.fDistance = sqrt(m_tTargetingInfo.fDistanceSq); 
+
+	// 혹시 모를 0 나누기 방지
+	if (m_tTargetingInfo.fDistance > 1e-12f) {
+		vDirToTarget.Normalize();
+	}
+	m_tTargetingInfo.vDirToTarget = vDirToTarget;
+
+	// 평면 XZ상 내적 계산
+	_vector3 vSelfLookH = m_tTargetingInfo.vDirSelfLook;
+	vSelfLookH.y = 0.f;
+	vSelfLookH.Normalize();
+	m_tTargetingInfo.fDotTarget = vSelfLookH.Dot(m_tTargetingInfo.vDirToTarget);
+
+	// 3D공간상 내적(XYZ)
+	//m_tTargetingInfo.fDotTarget = m_tTargetingInfo.vDirSelfLook.Dot(m_tTargetingInfo.vDirToTarget);
+}
+
+void CEnemy::Render_GUI_ForTargetInfo()
+{
+	ImGui::PushID(this);
+
+	float childWidth = ImGui::GetContentRegionAvail().x;
+	const float textLineHeight = ImGui::GetTextLineHeightWithSpacing();
+	const float childHeight = (textLineHeight * 8) + (ImGui::GetStyle().WindowPadding.y * 2);
+
+	ImGui::SeparatorText("For Target Information");
+	auto pCharacter = GetCharacterOnField();
+	if (nullptr != pCharacter) {
+		ImGui::BeginChild("TracePlayer##ThugBulkyEnforcerTracePlayer", ImVec2{ 0, childHeight }, true);
+
+		ImGui::Text("Character Name : %s", pCharacter->TagInstanceName);
+		ImGui::Text("Character Pos : %.2f, %.2f, %.2f", m_tTargetingInfo.vTargetPos.x, m_tTargetingInfo.vTargetPos.y, m_tTargetingInfo.vTargetPos.z);
+		ImGui::Text("Character CCT Radius : %.2f", pCharacter->fRadius);;
+		ImGui::Text("Distance From Character : %.3f", m_tTargetingInfo.fDistance);
+		ImGui::Text("Dot with Target : %.2f", m_tTargetingInfo.fDotTarget);
+		ImGui::Text("Dir To Target : %.2f, %.2f, %.2f", m_tTargetingInfo.vDirToTarget.x, m_tTargetingInfo.vDirToTarget.y, m_tTargetingInfo.vDirToTarget.z);
+		ImGui::BeginDisabled(true);
+		ImGui::Checkbox(u8"isDetected", &m_tTargetingInfo.isDetected);
+		ImGui::EndDisabled();
+
+		ImGui::EndChild();
+	}
+	ImGui::PopID();
 }
 
 void CEnemy::Free()

--- a/TeamProject/Client/Private/ThugBulkyEnforcer.cpp
+++ b/TeamProject/Client/Private/ThugBulkyEnforcer.cpp
@@ -66,7 +66,7 @@ HRESULT CThugBulkyEnforcer::Initialize(INIT_DESC* pArg)
 
 	if (FAILED(Initialize_StateMachine()))
 		return E_FAIL;
-	
+
 	// 임시 확인용
 	CGameInstance::GetInstance()->Get_GUISystem()->Get_Context()->pSelectedObject = this;
 
@@ -113,12 +113,21 @@ void CThugBulkyEnforcer::Render_GUI()
 	}
 	// =======================================================
 #pragma region State
-	ImGui::BeginChild("State##ThugBulkyEnforcerStatus", ImVec2{ 0, childHeight + textLineHeight * 6}, true);
+	ImGui::SeparatorText("State & BlackBoard");
+	ImGui::BeginChild("State##ThugBulkyEnforcerStatus", ImVec2{ 0, childHeight + textLineHeight * 8}, true);
 	string TagCurState = "Current State : " + m_pStateMachine->Get_CurrentStateName();
 	ImGui::Text(TagCurState.c_str());
 	string TagCurChildState = "Current ChildState : " + m_tAttackBlackBoard.currentStateTag;
 	ImGui::Text(TagCurChildState.c_str());
+	string TagStateQueueSize = "StateQueue Size : " + to_string(m_tAttackBlackBoard.stateQueue.size());
+	ImGui::Text(TagStateQueueSize.c_str());
 
+	// bool 변수 확인용(수정 불가)
+	ImGui::BeginDisabled(true);
+	ImGui::Checkbox(u8"IsRequestNext (다음 상태 존재)", &m_tAttackBlackBoard.isRequestNext);
+	ImGui::Checkbox(u8"IsChainOpen (현재 상태 종료)", &m_tAttackBlackBoard.isChainOpen);
+	ImGui::Checkbox(u8"isEnd (Queue에 등록된 마지막 상태 여부)", &m_tAttackBlackBoard.isEnd);
+	ImGui::EndDisabled();
 	ImGui::SeparatorText("Reseve State List");
 	for (size_t i = 0; i < m_tAttackBlackBoard.stateQueue.size(); i++)
 	{
@@ -131,31 +140,24 @@ void CThugBulkyEnforcer::Render_GUI()
 	ImGui::EndChild();
 #pragma endregion
 	// =======================================================
-	ImGui::BeginChild("BlackBoard##ThugBulkyEnforcerBlackBoard", ImVec2{ 0, childHeight + textLineHeight * 6 }, true);
-	string TagBlackBoardCurState = "Current State : " + m_tAttackBlackBoard.currentStateTag;
-	ImGui::Text(TagBlackBoardCurState.c_str());
-	string TagStateQueueSize = "StateQueue Size : " + to_string(m_tAttackBlackBoard.stateQueue.size());
-	ImGui::Text(TagStateQueueSize.c_str());
-
-	// bool 변수 확인용(수정 불가)
-	ImGui::BeginDisabled(true);
-	ImGui::Checkbox(u8"IsRequestNext(다음 상태 존재)", &m_tAttackBlackBoard.isRequestNext);
-	ImGui::Checkbox(u8"IsChainOpen(현재 상태 종료)", &m_tAttackBlackBoard.isChainOpen);
-	ImGui::Checkbox(u8"isEnd(Queue에 등록된 마지막 상태 여부)", &m_tAttackBlackBoard.isEnd);
-	ImGui::EndDisabled();
-
-	ImGui::EndChild();
-	// =======================================================
-	auto pCharacter = GetCharacterOnField();
-	if (nullptr != pCharacter) {
-		ImGui::BeginChild("TracePlayer##ThugBulkyEnforcerTracePlayer", ImVec2{ 0, childHeight /*+ textLineHeight * 6*/ }, true);
-
-		ImGui::Text("Character Name : %s", pCharacter->TagInstanceName);
-		ImGui::Text("Character Pos : %.2f, %.2f, %.2f", pCharacter->vPos.x, pCharacter->vPos.y, pCharacter->vPos.z);
-		ImGui::Text("Character CCT Radius : %.2f", pCharacter->fRadius);;
-
-	ImGui::EndChild();
-	}
+	//ImGui::SeparatorText("For Target Information");
+	//auto pCharacter = GetCharacterOnField();
+	//if (nullptr != pCharacter) {
+	//	ImGui::BeginChild("TracePlayer##ThugBulkyEnforcerTracePlayer", ImVec2{ 0, childHeight + textLineHeight * 6 }, true);
+	//
+	//	ImGui::Text("Character Name : %s", pCharacter->TagInstanceName);
+	//	ImGui::Text("Character Pos : %.2f, %.2f, %.2f", pCharacter->vPos.x, pCharacter->vPos.y, pCharacter->vPos.z);
+	//	ImGui::Text("Character CCT Radius : %.2f", pCharacter->fRadius);;
+	//	ImGui::Text("Distance From Character : %.3f", m_tTargetingInfo.fDistance);
+	//	ImGui::Text("Dot with Target : %.2f", m_tTargetingInfo.fDotTarget);
+	//	ImGui::Text("Dir To Target : %.2f, %.2f, %.2f", m_tTargetingInfo.vDirToTarget.x, m_tTargetingInfo.vDirToTarget.y, m_tTargetingInfo.vDirToTarget.z);
+	//	ImGui::BeginDisabled(true);
+	//	ImGui::Checkbox(u8"isDetected (플레이어 감지)", &m_tTargetingInfo.isDetected);
+	//	ImGui::EndDisabled();
+	//
+	//ImGui::EndChild();
+	//}
+	Render_GUI_ForTargetInfo();
 	// =======================================================
 	
 	ImGui::Checkbox("Auto Pattern", &m_isAutoPatternPlay);
@@ -283,7 +285,11 @@ HRESULT CThugBulkyEnforcer::Initialize_Transitions()
 
 HRESULT CThugBulkyEnforcer::Ready_Rules()
 {
+	// x = Idle에서 다음 상태로 넘어가는 쿨타임, y = dt 더한 타이머용
 	m_vIdleTime = { 0.2f, 0.f };
+
+	// Target 감지 범위 (default = 5.f)
+	m_fDetectedRange = 10.f;
 
 	return S_OK;
 }
@@ -298,6 +304,7 @@ void CThugBulkyEnforcer::Update_States(_float dt)
 		m_isIdle = false;
 	}
 
+	CheckDistanceFromPlayer();
 
 	if (true == m_isAutoPatternPlay &&
 		"Idle" == m_pStateMachine->Get_CurrentStateName()) {
@@ -317,8 +324,8 @@ void CThugBulkyEnforcer::Update_States(_float dt)
 	}
 }
 
-void CThugBulkyEnforcer::Test_State()
+void CThugBulkyEnforcer::CheckDistanceFromPlayer()
 {
-	
-
+	if (true == m_tTargetingInfo.isDetected)
+		m_pStateMachine->Set_Bool("Chase", true);
 }

--- a/TeamProject/Client/Public/Enemy.h
+++ b/TeamProject/Client/Public/Enemy.h
@@ -11,6 +11,18 @@ typedef struct tagAttackBlackBoard
     string currentStateTag{};
 }ATTACK_BLACK_BOARD;
 
+// 플레이어와 몬스터 사이의 정보를 담은 구조체
+typedef struct tagTargetingSpatialInfo {
+    _vector3    vSelfPos;
+    _vector3    vTargetPos;
+    _vector3    vDirSelfLook;
+    _vector3    vDirToTarget;   // 몬스터->플레이어를 바라보는 방향
+    _float      fDotTarget;     // 1.0이면 정면, 0이면 90도(옆), -1.0이면 정반대 뒤쪽을 의미
+    _float      fDistance;      // 제곱근 (실제 거리) 
+    _float      fDistanceSq;    // 제곱한 거리
+    _bool       isDetected = false; // Enemy-m_fDetectedRange 범위 안에 감지가 되면 true
+}TARGETING_INFO;
+
 class CEnemy abstract:
     public CGameObject
 {
@@ -28,9 +40,20 @@ public:
 
 public:
     BATTLEOBJ_INFO*     GetCharacterOnField();
+    TARGETING_INFO&     GetTargetingInfo() { return m_tTargetingInfo; }
+    void                ComputeTargetingInfo();
 
 protected:
+    // Target(Player-Character)이 있을 때, Target의 정보와 Target으로 부터의 정보 GUI에 렌더
+    void                Render_GUI_ForTargetInfo();
+
+protected:
+    // BattleSystem으로 부터 얻어온 Character정보
     vector<BATTLEOBJ_INFO>  m_PlayerCharacterInfos; 
+    // Target(Player-Character)이 있을 때, Target 사이의 정보 구조체
+    TARGETING_INFO          m_tTargetingInfo = {};
+    // 플레이어를 감지하는 사거리 범위(공격용 사거리 혹은 추격용으로 사용)
+    _float                  m_fDetectedRange = { 5.f };    
  
 protected: 
     virtual CGameObject* Clone(INIT_DESC* pArg) PURE;

--- a/TeamProject/Client/Public/ThugBulkyEnforcer.h
+++ b/TeamProject/Client/Public/ThugBulkyEnforcer.h
@@ -38,7 +38,7 @@ private:
     HRESULT Initialize_Transitions();
     HRESULT Ready_Rules();
     void Update_States(_float dt);
-    void Test_State();
+    void CheckDistanceFromPlayer();
 
 private:
     CStateMachine<CThugBulkyEnforcer>* m_pStateMachine = { nullptr };


### PR DESCRIPTION
- Enemy 클래스 내부에서 Update때 BattleSystem에서 플레이어(캐릭터들)의 정보를 받아옴. 
매프레임 초기화 후 계산
- 받아옴과 동시에 해당 몬스터와 현재 필드 위에 올라온 플레이어 사이의 거리정보들을 계산해서 멤버 변수에 저장해둠. 
매프레임 초기화 후 계산
- GUI로 해당 값들 확인할 수 있는 API 추가