### PR TITLE
refactor : 배틀쪽 UI 호출 관련해서 리팩토링 #529

### DIFF
--- a/TeamProject/Client/Private/CamDirector.cpp
+++ b/TeamProject/Client/Private/CamDirector.cpp
@@ -139,8 +139,6 @@ void CCamDirector::StartBattleIntro(CamSeqType type)
 {
     AutoTarget();
     RequestSequence(type);
-    UIDirector()->Hide_HUD(CUIDirector::HUD::BATTLE);
-    UIDirector()->Show_SceneFrame();
 }
 
 string CCamDirector::ResolveSeqKey(CamSeqType type) const

--- a/TeamProject/Client/Private/Stage.cpp
+++ b/TeamProject/Client/Private/Stage.cpp
@@ -196,6 +196,9 @@ void CStage::BaseIntro(CZero_Level::StageContext& context)
 			{
 				BattleSystem()->GetBattlePlayer()->QuestStart();
 				CamDirector()->StartBattleIntro(CamSeqType::ZeroIntro);
+
+				UIDirector()->Hide_HUD(CUIDirector::HUD::BATTLE);
+				UIDirector()->Show_SceneFrame();
 			}
 				});
 			m_introFlow.AddWaitUntil(seqId, []()
@@ -234,16 +237,17 @@ void CStage::BossIntro(CZero_Level::StageContext& context)
 			//BattleSystem()->GetBattlePlayer()->QuestStart();
 			CamDirector()->StartBattleIntro(CamSeqType::BattleIntro);
 
+			UIDirector()->Hide_HUD(CUIDirector::HUD::BATTLE);
+			UIDirector()->Show_SceneFrame();
 			});
 		m_introFlow.AddWaitUntil(seqId, []()
 			{
 				//return !CamDirector()->IsPlaying(CamSeqType::ZeroIntro);
 				return !CamDirector()->IsPlaying(CamSeqType::BattleIntro);
 			});
-		m_introFlow.AddOnce(seqId, [context]() {if (context.isFirstIn)
-		{
-			CUIDirector::GetInstance()->Show_HUD(CUIDirector::HUD::BATTLE);
-		}
+		m_introFlow.AddOnce(seqId, [context]()
+			{
+				CUIDirector::GetInstance()->Show_HUD(CUIDirector::HUD::BATTLE);
 			});
 		m_introFlow.EndSequence(seqId);
 	}


### PR DESCRIPTION
- Hide_HUD, Show_SceneFrame 호출을 캠 디렉터의 StartBattleIntro가 아니라 Stage에서 하도록 수정
- 보스 인트로에서 배틀 HUD가 안 보여서 조건문 뺌